### PR TITLE
Add negative input validation to factorial implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,10 @@ console.log(fibonacci(6)); // Output: 8
 
 ```js
 function factorial(n) {
-  if (n === 0) return 1;
+  if (n < 0) throw new RangeError('Factorial is not defined for negative numbers');
+
+  if (n === 0 || n === 1) return 1;
+
   return n * factorial(n - 1);
 }
 


### PR DESCRIPTION
This PR improves the existing `factorial(n)` function by adding input validation for negative numbers. Previously, calling `factorial(-1)` or any negative input would cause **infinite recursion**, eventually leading to a stack overflow. With this update, a `RangeError` is thrown when a negative number is passed.

### Why this change is important:

- **Correctness**: Mathematically, factorial is not defined for negative numbers.
- **Robustness**: Prevents infinite recursion and potential stack overflow on invalid input.
- **Interview relevance**: Input validation is a common area of oversight in candidate solutions. This change aligns the function with real-world expectations.
- **Clarity and semantics**: Using `RangeError` instead of a generic `Error` makes it immediately clear that the issue is with the **range of acceptable values**, not a syntax issue or unexpected type. According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RangeError), `RangeError` is appropriate when a value is **not within the set or range of allowed values** — which fits this case perfectly.

```javascript
factorial(-5); // throws RangeError: Factorial is not defined for negative numbers
factorial(5);  // returns 120
```

*The updated function stays concise and educational while being safer and more professional.*